### PR TITLE
upgrade gha and golangci(to 2.10)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v2.1.6
+# v2.10.1
 # Please don't remove the first line. It uses in CI to determine the golangci version
 version: "2"
 linters:
@@ -39,6 +39,7 @@ linters:
     - lll
     - makezero
     - misspell
+    - modernize
     - nakedret
     - nestif
     - nilerr
@@ -76,6 +77,7 @@ linters:
         - pattern: ^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?
         - pattern: ^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?
         - pattern: ^logrus\.Logger$
+        - pattern: ^afero\.(.*)$(# Using afero outside of the fsext package is forbidden )?
     funlen:
       lines: 80
       statements: 60
@@ -95,6 +97,7 @@ linters:
           - funlen
           - gocognit
           - lll
+          - gosec
         path: _(test|gen)\.go
       - linters:
           - contextcheck
@@ -115,6 +118,16 @@ linters:
       - linters:
           - forbidigo
         text: use of `os\.(SyscallError|Signal|Interrupt)` forbidden
+      - linters:
+          - forbidigo
+        text: use of `afero\.(.*)` forbidden
+        path: lib/fsext/.*\.go
+      - linters:
+          - revive
+        text: avoid meaningless package names
+      - linters:
+          - revive
+        text: avoid package names that conflict with Go standard library
     paths:
       - third_party$
       - builtin$

--- a/encoding/module.go
+++ b/encoding/module.go
@@ -48,7 +48,7 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 // Exports implements the modules.Instance interface and returns
 // the exports of the JS module.
 func (mi *ModuleInstance) Exports() modules.Exports {
-	return modules.Exports{Named: map[string]interface{}{
+	return modules.Exports{Named: map[string]any{
 		"TextDecoder": mi.NewTextDecoder,
 		"TextEncoder": mi.NewTextEncoder,
 	}}

--- a/encoding/sobek.go
+++ b/encoding/sobek.go
@@ -62,10 +62,7 @@ func exportArrayBuffer(rt *sobek.Runtime, v sobek.Value) ([]byte, error) {
 			return nil, errors.New("DataView byteOffset out of bounds")
 		}
 
-		end := byteOffset + byteLength
-		if end > int64(len(allBytes)) {
-			end = int64(len(allBytes))
-		}
+		end := min(byteOffset+byteLength, int64(len(allBytes)))
 
 		return allBytes[byteOffset:end], nil
 	} else {

--- a/encoding/sobek.go
+++ b/encoding/sobek.go
@@ -40,7 +40,7 @@ func exportArrayBuffer(rt *sobek.Runtime, v sobek.Value) ([]byte, error) {
 	var ab sobek.ArrayBuffer
 	var ok bool
 
-	if IsTypedArray(rt, v) { //nolint:nestif
+	if IsTypedArray(rt, v) { //nolint:nestif,gocritic
 		ab, ok = asObject.Get("buffer").Export().(sobek.ArrayBuffer)
 		if !ok {
 			return nil, errors.New("TypedArray.buffer is not an ArrayBuffer")

--- a/encoding/text_decoder.go
+++ b/encoding/text_decoder.go
@@ -209,10 +209,10 @@ func (td *TextDecoder) decodeUTF16(buffer []byte, options TextDecodeOptions) (st
 
 	var decoded string
 	var err error
-	var consumed int
 
 	if processLen > 0 {
 		toDecode := td.buffer[:processLen]
+		var consumed int
 		decoded, consumed, err = td.applyTransform(toDecode, !stream)
 		td.buffer = append(td.buffer[:0], td.buffer[consumed:]...)
 	} else {

--- a/encoding/text_decoder.go
+++ b/encoding/text_decoder.go
@@ -124,9 +124,6 @@ func NewTextDecoder(rt *sobek.Runtime, label string, options TextDecoderOptions)
 	return td, nil
 }
 
-// replacementCharUTF8 is the UTF-8 encoded form of U+FFFD.
-var replacementCharUTF8 = []byte{0xEF, 0xBF, 0xBD}
-
 // Decode takes a byte stream as input and returns a string.
 func (td *TextDecoder) Decode(buffer []byte, options TextDecodeOptions) (string, error) {
 	if td.decoder == nil {
@@ -331,6 +328,9 @@ func (td *TextDecoder) resetState() {
 }
 
 func sanitizeUTF8Bytes(data []byte, stream bool) (processed []byte, leftover []byte, hadInvalid bool) {
+	// replacementCharUTF8 is the UTF-8 encoded form of U+FFFD.
+	replacementCharUTF8 := []byte{0xEF, 0xBF, 0xBD}
+
 	if len(data) == 0 {
 		return nil, nil, false
 	}

--- a/encoding/text_decoder.go
+++ b/encoding/text_decoder.go
@@ -149,7 +149,7 @@ func (td *TextDecoder) decodeUTF8(buffer []byte, options TextDecodeOptions) (str
 		}
 	}
 
-	combined := append(td.buffer, buffer...)
+	combined := append(td.buffer, buffer...) //nolint:gocritic
 	td.buffer = td.buffer[:0]
 
 	processed, leftover, hadInvalid := sanitizeUTF8Bytes(combined, stream)

--- a/encoding/text_decoder.go
+++ b/encoding/text_decoder.go
@@ -278,10 +278,7 @@ func (td *TextDecoder) applyTransform(input []byte, atEOF bool) (string, int, er
 		return "", 0, nil
 	}
 
-	destSize := len(input)*4 + 64
-	if destSize < 64 {
-		destSize = 64
-	}
+	destSize := max(len(input)*4+64, 64)
 	dest := make([]byte, destSize)
 
 	var (

--- a/encoding/text_decoder.go
+++ b/encoding/text_decoder.go
@@ -209,7 +209,7 @@ func (td *TextDecoder) decodeUTF16(buffer []byte, options TextDecodeOptions) (st
 
 	var decoded string
 	var err error
-	consumed := 0
+	var consumed int
 
 	if processLen > 0 {
 		toDecode := td.buffer[:processLen]

--- a/encoding/text_decoder.go
+++ b/encoding/text_decoder.go
@@ -442,8 +442,6 @@ type TextDecodeOptions struct {
 }
 
 // Name is a type alias for the name of an encoding.
-//
-//nolint:revive
 type Name = string
 
 const (

--- a/encoding/text_decoder_test.go
+++ b/encoding/text_decoder_test.go
@@ -34,6 +34,8 @@ func TestTextDecoderUTF8StreamingStateMachine(t *testing.T) {
 	t.Parallel()
 
 	t.Run("IncompleteThenInvalidContinuation", func(t *testing.T) {
+		t.Parallel()
+
 		td := &TextDecoder{
 			TextDecoderCommon: TextDecoderCommon{
 				Encoding: UTF8EncodingFormat,
@@ -55,6 +57,8 @@ func TestTextDecoderUTF8StreamingStateMachine(t *testing.T) {
 	})
 
 	t.Run("ImmediateInvalidStartByte", func(t *testing.T) {
+		t.Parallel()
+
 		td := &TextDecoder{
 			TextDecoderCommon: TextDecoderCommon{
 				Encoding: UTF8EncodingFormat,
@@ -72,6 +76,8 @@ func TestTextDecoderUTF8StreamingStateMachine(t *testing.T) {
 	})
 
 	t.Run("ASCIIStreamingProducesOutput", func(t *testing.T) {
+		t.Parallel()
+
 		td := &TextDecoder{
 			TextDecoderCommon: TextDecoderCommon{
 				Encoding: UTF8EncodingFormat,
@@ -93,6 +99,8 @@ func TestTextDecoderUTF8StreamingStateMachine(t *testing.T) {
 	})
 
 	t.Run("FatalFlushOnTruncatedSequence", func(t *testing.T) {
+		t.Parallel()
+
 		td := &TextDecoder{
 			TextDecoderCommon: TextDecoderCommon{
 				Encoding:  UTF8EncodingFormat,
@@ -122,6 +130,8 @@ func TestTextDecoderUTF16FatalStreaming(t *testing.T) {
 	}
 
 	t.Run("OddFollowedByOddCompletes", func(t *testing.T) {
+		t.Parallel()
+
 		td := newFatalDecoder()
 
 		out, err := td.Decode([]byte{0x00}, TextDecodeOptions{Stream: true})
@@ -134,6 +144,8 @@ func TestTextDecoderUTF16FatalStreaming(t *testing.T) {
 	})
 
 	t.Run("EvenThenOddThrows", func(t *testing.T) {
+		t.Parallel()
+
 		td := newFatalDecoder()
 
 		out, err := td.Decode([]byte{0x00, 0x00}, TextDecodeOptions{Stream: true})
@@ -145,6 +157,8 @@ func TestTextDecoderUTF16FatalStreaming(t *testing.T) {
 	})
 
 	t.Run("OddThenEvenThrows", func(t *testing.T) {
+		t.Parallel()
+
 		td := newFatalDecoder()
 
 		out, err := td.Decode([]byte{0x00}, TextDecodeOptions{Stream: true})
@@ -156,6 +170,8 @@ func TestTextDecoderUTF16FatalStreaming(t *testing.T) {
 	})
 
 	t.Run("EvenChunksStreamSuccessfully", func(t *testing.T) {
+		t.Parallel()
+
 		td := newFatalDecoder()
 
 		out, err := td.Decode([]byte{0x00, 0x00}, TextDecodeOptions{Stream: true})


### PR DESCRIPTION
- upgrade actions/checkout to v7
- upgrade actions/setup-go to v6
- upgrade actions/golangci-lint-action to v9
  - upgrade golangci-lint to v2.10 (sync with k6)
    - some lints are fixed.
- upgrade Golang(GHA) to 1.26(sync with k6)

## passed tests

- https://github.com/arukiidou/xk6-encoding/pull/1