### PR TITLE
update GHA actions/checkout@v7 and actions/setup-go@v6, Go 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
   xk6-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
 
       - name: Build using xk6
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
 
       - name: Run tests
         run: |


### PR DESCRIPTION
- Leftover #5 tasks from the GHA update